### PR TITLE
fix: secure default bind, worker threads, unknown command error

### DIFF
--- a/src/main/java/org/unlaxer/infra/syslenz4j/SyslenzAgent.java
+++ b/src/main/java/org/unlaxer/infra/syslenz4j/SyslenzAgent.java
@@ -43,12 +43,14 @@ public final class SyslenzAgent {
      * <p>デーモンスレッドで動作し、JVM のシャットダウンを妨げない。
      * {@code SNAPSHOT\n} コマンドに ProcEntry JSON で応答する。
      * 複数回呼んでも安全（既に起動中なら無視）。
-     * バインドアドレスは {@code 0.0.0.0}（全インタフェース）。
+     * デフォルトのバインドアドレスは {@code 127.0.0.1}（ループバックのみ）。
+     * 外部インタフェースへの公開が必要な場合は
+     * {@link #startServer(int, String)} で明示的に指定してください。
      *
      * @param port TCP ポート（例: 9100）
      */
     public static void startServer(int port) {
-        startServer(port, "0.0.0.0");
+        startServer(port, "127.0.0.1");
     }
 
     /**

--- a/src/main/java/org/unlaxer/infra/syslenz4j/SyslenzServer.java
+++ b/src/main/java/org/unlaxer/infra/syslenz4j/SyslenzServer.java
@@ -10,6 +10,9 @@ import java.net.SocketTimeoutException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Lightweight TCP server compatible with the {@code syslenz --connect} protocol.
@@ -22,10 +25,9 @@ import java.util.Map;
  *   <li>Connection may be kept open for further requests or closed by either side.</li>
  * </ol>
  *
- * <p>The server runs on a single daemon thread using blocking I/O. Each
- * accepted connection is handled sequentially (adequate for a monitoring
- * endpoint that is polled every few seconds). If higher concurrency is
- * needed, wrap the handler in a thread pool.
+ * <p>The server runs on a single daemon thread for accepting connections.
+ * Each accepted connection is dispatched to a worker thread pool so that
+ * idle or slow clients cannot block other connections.
  */
 public class SyslenzServer {
 
@@ -39,14 +41,15 @@ public class SyslenzServer {
     private volatile ServerSocket serverSocket;
     private volatile Thread serverThread;
     private volatile boolean running;
+    private ExecutorService workerPool;
 
     SyslenzServer(int port, MetricRegistry registry) {
-        this(port, "0.0.0.0", registry, null);
+        this(port, "127.0.0.1", registry, null);
     }
 
     SyslenzServer(int port, String bindAddress, MetricRegistry registry, WatchRegistry watchRegistry) {
         this.port = port;
-        this.bindAddress = bindAddress != null ? bindAddress : "0.0.0.0";
+        this.bindAddress = bindAddress != null ? bindAddress : "127.0.0.1";
         this.registry = registry;
         this.watchRegistry = watchRegistry;
     }
@@ -57,6 +60,12 @@ public class SyslenzServer {
     void start() {
         if (running) return;
         running = true;
+
+        workerPool = Executors.newCachedThreadPool(r -> {
+            Thread t = new Thread(r, "syslenz-worker-" + port);
+            t.setDaemon(true);
+            return t;
+        });
 
         serverThread = new Thread(this::acceptLoop, "syslenz-server-" + port);
         serverThread.setDaemon(true);
@@ -76,6 +85,15 @@ public class SyslenzServer {
         } catch (IOException ignored) {
             // best effort
         }
+        ExecutorService pool = workerPool;
+        if (pool != null) {
+            pool.shutdown();
+            try {
+                pool.awaitTermination(5, TimeUnit.SECONDS);
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            }
+        }
     }
 
     // ----- Internal ------------------------------------------------------
@@ -93,14 +111,17 @@ public class SyslenzServer {
                 } catch (SocketTimeoutException e) {
                     continue; // check running flag
                 }
-                try {
-                    handleClient(client);
-                } catch (Exception e) {
-                    // Log to stderr but don't crash the server
-                    System.err.println("[syslenz-server] client error: " + e.getMessage());
-                } finally {
-                    try { client.close(); } catch (IOException ignored) {}
-                }
+                final Socket finalClient = client;
+                workerPool.submit(() -> {
+                    try {
+                        handleClient(finalClient);
+                    } catch (Exception e) {
+                        // Log to stderr but don't crash the server
+                        System.err.println("[syslenz-server] client error: " + e.getMessage());
+                    } finally {
+                        try { finalClient.close(); } catch (IOException ignored) {}
+                    }
+                });
             }
         } catch (SocketException e) {
             if (running) {
@@ -126,8 +147,13 @@ public class SyslenzServer {
                 out.write(json.getBytes("UTF-8"));
                 out.write('\n');
                 out.flush();
+            } else {
+                // Unknown command: return an error response and close the connection
+                String error = "ERROR unknown command: " + trimmed + "\n";
+                out.write(error.getBytes("UTF-8"));
+                out.flush();
+                return;
             }
-            // Unknown commands are silently ignored
         }
     }
 

--- a/src/test/java/org/unlaxer/infra/syslenz4j/LocalhostBindingTest.java
+++ b/src/test/java/org/unlaxer/infra/syslenz4j/LocalhostBindingTest.java
@@ -42,13 +42,13 @@ class LocalhostBindingTest {
     }
 
     @Test
-    void startServerDefaultBindsToAllInterfaces() throws Exception {
+    void startServerDefaultBindsToLoopback() throws Exception {
         int port = 19192;
-        SyslenzAgent.startServer(port); // default: 0.0.0.0
+        SyslenzAgent.startServer(port); // default: 127.0.0.1
 
         Thread.sleep(200);
 
-        // Should be reachable via 127.0.0.1 too (loopback is part of 0.0.0.0)
+        // Should be reachable via 127.0.0.1 (default loopback bind)
         try (Socket socket = new Socket("127.0.0.1", port)) {
             assertTrue(socket.isConnected());
         }


### PR DESCRIPTION
Closes #5

## Changes

### 1. [High] Default bind changed to 127.0.0.1 (SyslenzAgent.java:50)
`startServer(int port)` now binds to `127.0.0.1` instead of `0.0.0.0`, preventing unauthenticated JVM metrics from being exposed on external network interfaces. Callers that need external access can use the explicit `startServer(int port, String bindAddress)` overload. Internal `SyslenzServer` constructors updated to match.

### 2. [Medium] Worker thread pool for client connections (SyslenzServer.java:83,115)
Each accepted connection is now dispatched to a `CachedThreadPool` worker thread instead of being handled inline on the accept loop. An idle client holding its connection for up to `SO_TIMEOUT=30s` no longer blocks all other clients. The pool is properly shut down on `stop()`.

### 3. [Low] Error response for unknown commands (SyslenzServer.java:130)
Unknown commands now receive an `ERROR unknown command: <cmd>` response and the connection is closed, so callers can reliably detect protocol errors rather than waiting indefinitely.

### Test update
`LocalhostBindingTest` method name and comment updated to reflect the new loopback-only default behaviour.